### PR TITLE
need duplicate count

### DIFF
--- a/gocoverutil/gocoverutil.go
+++ b/gocoverutil/gocoverutil.go
@@ -60,11 +60,6 @@ func Merge(inputFiles []string, outputFile string) error {
 		var newBlocks []cover.ProfileBlock
 		var prev cover.ProfileBlock
 		for _, b := range blocks[file] {
-			// skip full duplicate
-			if prev == b {
-				continue
-			}
-
 			// change count inside previous block if only count changed
 			prev.Count = b.Count
 			if prev == b {


### PR DESCRIPTION
Hi AlekSi!
In E2E test, we merge different scenarios coverage files together. Different scenarios may depend on the same file with the same line, same column and the same count. So it is better to remove the duplicate check to avoid mistacks.